### PR TITLE
docs: replace <PROVIDER>-<NAME> placeholders in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,12 @@
 
 ### Table Of Contents
 
-* [Before getting started?](#before-getting-started)
-
-* [How to Contribute?](#how-can-i-contribute)
-    * [Reporting Bugs](#reporting-bugs)
-    * [Feature Requests](#feature-requests)
-    * [Pull Requests](#creating-a-pull-request)
-
-* [Developer Guidelines](/DEVELOPER_GUIDELINES.md)
-
+- [Contributing to the Lacework Terraform Modules](#contributing-to-the-lacework-terraform-modules)
+    - [Table Of Contents](#table-of-contents)
+  - [Before getting started](#before-getting-started)
+  - [Reporting Bugs](#reporting-bugs)
+  - [Feature Requests](#feature-requests)
+  - [Creating a Pull Request](#creating-a-pull-request)
 
 ## Before getting started
 
@@ -19,21 +16,20 @@ Read the [README.md](README.md) and
 
 ## Reporting Bugs
 
-Ensure the issue you are raising has not already been created under [issues](https://github.com/lacework/terraform-<PROVIDER>-<NAME>/issues).
-If no current issue addresses the problem, open a new [issue](https://github.com/lacework/terraform-<PROVIDER>-<NAME>/issues/new).
-Include as much relevant information as possible. See the [bug template](https://github.com/lacework/terraform-<PROVIDER>-<NAME>/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) for help on creating a new issue.
+Ensure the issue you are raising has not already been created under [issues](https://github.com/lacework/terraform-oci-iam-user/issues).
+If no current issue addresses the problem, open a new [issue](https://github.com/lacework/terraform-oci-iam-user/issues/new).
+Include as much relevant information as possible. See the [bug template](https://github.com/lacework/terraform-oci-iam-user/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) for help on creating a new issue.
 
 ## Feature Requests
 
-If you wish to submit a request to add new functionality or an improvement to a terraform module then use the the [feature request](https://github.com/lacework/terraform-<PROVIDER>-<NAME>/blob/main/.github/ISSUE_TEMPLATE/feature_request.md) template to 
-open a new [issue](https://github.com/lacework/terraform-<PROVIDER>-<NAME>/issues/new)
+If you wish to submit a request to add new functionality or an improvement to a terraform module then use the the [feature request](https://github.com/lacework/terraform-oci-iam-user/blob/main/.github/ISSUE_TEMPLATE/feature_request.md) template to
+open a new [issue](https://github.com/lacework/terraform-oci-iam-user/issues/new)
 
 ## Creating a Pull Request
 
 If you have made a change or added new functionality, you can submit a pull request. The project maintainers will aim to review in a 2 week timeframe. When submitting a pull request please read the [developer guidelines](/DEVELOPER_GUIDELINES.md)
 
 The examples folder contains Terraform code that run as part of the CI pipeline. A new pull request will trigger this test run to ensure no breaking changes are added. We recommended sanity checking your own Terraform changes before submitting the change for review.
-
 
 Thanks,
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

There were a few <PROVIDER>-<NAME> placeholders that I hadn't replaced yet. This should be the last of them.

## How did you test this change?

I searched for all remaining <PROVIDER>-<NAME> placeholders:
```
rg "<PROVIDER>-<NAME>"
```
and the search came up empty.

## Issue

N/A