### PR TITLE
feat: make email a required parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_base_name"></a> [base\_name](#input\_base\_name) | Names for the created resources will be ${base\_name}\_{user,group} | `string` | `"lacework_security_integration"` | no |
 | <a name="input_create"></a> [create](#input\_create) | Set to false to prevent module from creating any resources | `bool` | `true` | no |
-| <a name="input_email"></a> [email](#input\_email) | Optional email associated with the created user | `string` | `"lacework@lacework.net"` | no |
+| <a name="input_email"></a> [email](#input\_email) | Email associated with the created user | `string` | n/a | yes |
 | <a name="input_freeform_tags"></a> [freeform\_tags](#input\_freeform\_tags) | freeform tags for the resources created for Lacework integration | `map(any)` | `{}` | no |
 | <a name="input_group_name"></a> [group\_name](#input\_group\_name) | Name of the identity group for the Lacework user (overrides base\_name) | `string` | `""` | no |
 | <a name="input_tenancy_id"></a> [tenancy\_id](#input\_tenancy\_id) | OCID of the OCI tenancy to be integrated with Lacework | `string` | n/a | yes |

--- a/examples/custom-iam-user/main.tf
+++ b/examples/custom-iam-user/main.tf
@@ -1,6 +1,7 @@
 module "lacework_iam_user" {
   source = "../.."
   tenancy_id = var.tenancy_ocid
+  email = "example@example.com"
 	base_name = "lacework_test"
 }
 

--- a/examples/default-iam-user/main.tf
+++ b/examples/default-iam-user/main.tf
@@ -1,6 +1,7 @@
 module "lacework_iam_user" {
   source = "../.."
   tenancy_id = var.tenancy_ocid
+  email = "example@example.com"
 }
 
 variable "tenancy_ocid" {

--- a/examples/skip-creation-iam-user/main.tf
+++ b/examples/skip-creation-iam-user/main.tf
@@ -1,6 +1,7 @@
 module "lacework_iam_user" {
   source = "../.."
   tenancy_id = var.tenancy_ocid
+  email = "example@example.com"
   create = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,11 @@ variable "tenancy_id" {
   description = "OCID of the OCI tenancy to be integrated with Lacework"
 }
 
+variable "email" {
+  type        = string
+  description = "Email associated with the created user"
+}
+
 # Optional
 
 variable "create" {
@@ -17,12 +22,6 @@ variable "freeform_tags" {
   type        = map(any)
   default     = {}
   description = "freeform tags for the resources created for Lacework integration"
-}
-
-variable "email" {
-  type        = string
-  default     = "lacework@lacework.net"
-  description = "Optional email associated with the created user"
 }
 
 variable "base_name" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This module creates an OCI user for the Lacework integration. OCI users need have an email. This PR makes the user email a required parameter instead of defaulting to 'lacework@lacework.net', which users do not have access to.

## How did you test this change?

Run the default example and make sure nothing broke:
```
cd examples/default-iam-user
tf init
TF_VAR_tenancy_ocid=<tenancy_ocid> tf plan
TF_VAR_tenancy_ocid=<tenancy_ocid> tf validate
```

## Issue

N/A