### PR TITLE
feat: rename base_name input to more descriptive name_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_base_name"></a> [base\_name](#input\_base\_name) | Names for the created resources will be ${base\_name}\_{user,group} | `string` | `"lacework_security_integration"` | no |
 | <a name="input_create"></a> [create](#input\_create) | Set to false to prevent module from creating any resources | `bool` | `true` | no |
 | <a name="input_email"></a> [email](#input\_email) | Email associated with the created user | `string` | n/a | yes |
 | <a name="input_freeform_tags"></a> [freeform\_tags](#input\_freeform\_tags) | freeform tags for the resources created for Lacework integration | `map(any)` | `{}` | no |
-| <a name="input_group_name"></a> [group\_name](#input\_group\_name) | Name of the identity group for the Lacework user (overrides base\_name) | `string` | `""` | no |
+| <a name="input_group_name"></a> [group\_name](#input\_group\_name) | Name of the identity group for the Lacework user (overrides name\_prefix) | `string` | `""` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Names for the created resources will be ${name\_prefix}\_{user,group} | `string` | `"lacework_security_integration"` | no |
 | <a name="input_tenancy_id"></a> [tenancy\_id](#input\_tenancy\_id) | OCID of the OCI tenancy to be integrated with Lacework | `string` | n/a | yes |
-| <a name="input_user_name"></a> [user\_name](#input\_user\_name) | Name of the IAM user used for Lacework integration (overrides base\_name) | `string` | `""` | no |
+| <a name="input_user_name"></a> [user\_name](#input\_user\_name) | Name of the IAM user used for Lacework integration (overrides name\_prefix) | `string` | `""` | no |
 
 ## Outputs
 
@@ -61,4 +61,3 @@ No modules.
 | <a name="output_user_ocid"></a> [user\_ocid](#output\_user\_ocid) | OCID of the user created for the Lacework integration |
 | <a name="output_user_private_key_pem"></a> [user\_private\_key\_pem](#output\_user\_private\_key\_pem) | The private key of the API key of the user created for integration |
 | <a name="output_user_public_key_fingerprint"></a> [user\_public\_key\_fingerprint](#output\_user\_public\_key\_fingerprint) | The public key fingerprint of the API key created for integration |
-

--- a/examples/custom-iam-user/README.md
+++ b/examples/custom-iam-user/README.md
@@ -6,12 +6,14 @@ resources.
 ```hcl
 module "lacework_iam_user" {
   source = "../.."
-  tenancy_id = var.tenancy_id
-  base_name = "lacework_test"
+  tenancy_id = var.tenancy_ocid
+  email = "example@example.com"
+	name_prefix = "lacework_test"
 }
 
-variable "tenancy_id" {
+variable "tenancy_ocid" {
   type = string
   description = "OCID of the tenancy to be integrated with Lacework"
 }
+
 ```

--- a/examples/custom-iam-user/main.tf
+++ b/examples/custom-iam-user/main.tf
@@ -2,7 +2,7 @@ module "lacework_iam_user" {
   source = "../.."
   tenancy_id = var.tenancy_ocid
   email = "example@example.com"
-	base_name = "lacework_test"
+	name_prefix = "lacework_test"
 }
 
 variable "tenancy_ocid" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
-  user_name  = length(var.user_name) > 0 ? var.user_name : "${var.base_name}_user"
-  group_name = length(var.group_name) > 0 ? var.group_name : "${var.base_name}_group"
+  user_name  = length(var.user_name) > 0 ? var.user_name : "${var.name_prefix}_user"
+  group_name = length(var.group_name) > 0 ? var.group_name : "${var.name_prefix}_group"
 }
 
 resource "oci_identity_user" "lacework_user" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,20 +24,20 @@ variable "freeform_tags" {
   description = "freeform tags for the resources created for Lacework integration"
 }
 
-variable "base_name" {
+variable "name_prefix" {
   type        = string
   default     = "lacework_security_integration"
-  description = "Names for the created resources will be $${base_name}_{user,group}"
+  description = "Names for the created resources will be $${name_prefix}_{user,group}"
 }
 
 variable "user_name" {
   type        = string
   default     = ""
-  description = "Name of the IAM user used for Lacework integration (overrides base_name)"
+  description = "Name of the IAM user used for Lacework integration (overrides name_prefix)"
 }
 
 variable "group_name" {
   type        = string
   default     = ""
-  description = "Name of the identity group for the Lacework user (overrides base_name)"
+  description = "Name of the identity group for the Lacework user (overrides name_prefix)"
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Renaming the `base_name` input variable to the more descriptive `name_prefix`. This module has just been published and is not in active use, so this does not break anything. Basically our last change to make breaking changes.

## How did you test this change?

Run plan/validate:
```sh
cd examples/default-iam-user
tf init
TF_VAR_tenancy_ocid=<tenancy_ocid> tf plan
TF_VAR_tenancy_ocid=<tenancy_ocid> tf validate
```

## Issue

This came about from a discussion in the terraform-oci-config repo on this PR: https://github.com/lacework/terraform-oci-config/pull/3