### PR TITLE
docs(SPM-1798): discuss OCI authentication in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 A Terraform Module to create a user and group to be used to integrate and OCI
 cloud account with Lacework.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -46,7 +47,7 @@ No modules.
 | <a name="input_email"></a> [email](#input\_email) | Email associated with the created user | `string` | n/a | yes |
 | <a name="input_freeform_tags"></a> [freeform\_tags](#input\_freeform\_tags) | freeform tags for the resources created for Lacework integration | `map(any)` | `{}` | no |
 | <a name="input_group_name"></a> [group\_name](#input\_group\_name) | Name of the identity group for the Lacework user (overrides name\_prefix) | `string` | `""` | no |
-| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Names for the created resources will be ${name\_prefix}\_{user,group} | `string` | `"lacework_security_integration"` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Names for the created resources will be ${name\_prefix}\_{user,group} | `string` | `"lw_"` | no |
 | <a name="input_tenancy_id"></a> [tenancy\_id](#input\_tenancy\_id) | OCID of the OCI tenancy to be integrated with Lacework | `string` | n/a | yes |
 | <a name="input_user_name"></a> [user\_name](#input\_user\_name) | Name of the IAM user used for Lacework integration (overrides name\_prefix) | `string` | `""` | no |
 

--- a/examples/custom-iam-user/README.md
+++ b/examples/custom-iam-user/README.md
@@ -1,14 +1,16 @@
 # Skip creation of resources
 
 This example shows how to use the Terraform module with custom names for
-resources.
+resources. The following example will use the OCI credentials in your
+~/.oci/config file. See the OCI Terraform Provider documentation [on
+authentication](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraformproviderconfiguration.htm) for alternative approaches of providing
+credentials to the OCI provider.
 
 ```hcl
 module "lacework_iam_user" {
-  source = "../.."
+  source = "lacework/iam-user/oci"
   tenancy_id = var.tenancy_ocid
   email = "example@example.com"
-	name_prefix = "lacework_test"
 }
 
 variable "tenancy_ocid" {

--- a/examples/custom-iam-user/main.tf
+++ b/examples/custom-iam-user/main.tf
@@ -2,7 +2,8 @@ module "lacework_iam_user" {
   source      = "../.."
   tenancy_id  = var.tenancy_ocid
   email       = "example@example.com"
-  name_prefix = "lacework_test"
+  user_name   = "custom_user_name"
+  group_name  = "custom_group_name"
 }
 
 variable "tenancy_ocid" {

--- a/examples/default-iam-user/README.md
+++ b/examples/default-iam-user/README.md
@@ -1,16 +1,20 @@
 # Default Example
 
-This example creates an IAM user, group, and policy needed for Lacework integration/
+This example creates an OCI user, group, and policy needed for Lacework
+integration. The following example will use the OCI credentials in your
+~/.oci/config file. See the OCI Terraform Provider documentation [on
+authentication](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraformproviderconfiguration.htm) for alternative approaches of providing
+credentials to the OCI provider.
 
 ```hcl
 module "lacework_iam_user" {
-  source = "../.."
+  source = "lacework/iam-user/oci"
   tenancy_id = var.tenancy_id
+  email = "email@example.com"
 }
 
 variable "tenancy_id" {
   type = string
   description = "OCID of the tenancy to be integrated with Lacework"
 }
-
 ```

--- a/examples/skip-creation-iam-user/README.md
+++ b/examples/skip-creation-iam-user/README.md
@@ -1,12 +1,17 @@
 # Skip creation of resources
 
 This example shows how to run the Terraform module without creating resources.
+The following example will use the OCI credentials in your
+~/.oci/config file. See the OCI Terraform Provider documentation [on
+authentication](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraformproviderconfiguration.htm) for alternative approaches of providing
+credentials to the OCI provider.
 
 ```hcl
 module "lacework_iam_user" {
-  source = "../.."
+  source = "lacework/iam-user/oci"
   tenancy_id = var.tenancy_id
   create = false
+  email = "email@example.com"
 }
 
 variable "tenancy_id" {

--- a/main.tf
+++ b/main.tf
@@ -48,5 +48,3 @@ resource "oci_identity_api_key" "lacework_api_key" {
   user_id   = oci_identity_user.lacework_user[count.index].id
   key_value = tls_private_key.rsa_key[count.index].public_key_pem
 }
-
-# Use public_key_fingerprint_md5, private_key_pem, public_key_pem 

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "freeform_tags" {
 
 variable "name_prefix" {
   type        = string
-  default     = "lacework_security_integration"
+  default     = "lw_"
   description = "Names for the created resources will be $${name_prefix}_{user,group}"
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Updating the module documentation with more explicit instructions on how to provide credentials to the OCI Terraform provider.

## How did you test this change?

There's no real logic change here, so the tests in the CI pipeline should be sufficient. 

## Issue

SPM-1798