### PR TITLE
ci: migrate from codefresh to github actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,9 @@
 name: Nightly Build
 
-on: workflow_dispatch
-
-  # schedule:
-  #   - cron: '0 10 * * *' # Run every day at 10AM UTC
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * *' # Run every day at 10AM UTC
 
 jobs:
   call-nightly-workflow:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,11 @@
 name: Release
 
-on: workflow_dispatch
-
+on: 
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+      
 jobs:
   call-nightly-workflow:
     uses: lacework/oss-actions/.github/workflows/tf-release.yml@main

--- a/.github/workflows/test-compat-pr-comment.yml
+++ b/.github/workflows/test-compat-pr-comment.yml
@@ -1,0 +1,29 @@
+name: Test Compatibility On Comment
+
+on: 
+  workflow_dispatch:
+  issue_comment:                                     
+    types: [created, edited]
+
+jobs:
+  check-commenting-user:
+    runs-on: ubuntu-latest
+    if: ${{  contains(github.event.comment.html_url, '/pull/') &&  contains(github.event.comment.body, 'make it so') }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const creator = context.payload.sender.login
+            const result = await github.rest.teams.getMembershipForUserInOrg({
+              org: context.repo.owner,
+              team_slug: 'growth-team',
+              username: creator
+            })
+            if (result.state != "active" ) {
+              core.setFailed('Commenter is not a member of the growth team.')
+            }
+            
+  call-test-compat:
+    needs: check-commenting-user
+    uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
+    secrets: inherit

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -8,6 +8,6 @@ on:
       - main
   
 jobs:
-  call-nightly-workflow:
+  call-test-compat:
     uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
     secrets: inherit

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -1,7 +1,12 @@
 name: Test Compatibility
 
-on: workflow_dispatch
-
+on: 
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  
 jobs:
   call-nightly-workflow:
     uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,6 +1,10 @@
 name: Verify Release
 
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - release
 
 jobs:
   call-nightly-workflow:


### PR DESCRIPTION
## Summary

These workflows replace the codefresh workflows of the same names as Lacework is migrating off of Codefresh.

## How did you test this change?

These work flows were first tested as much as possible in a non-main branch. Then in the main branch of a single terraform module (terraform-azure-activity-log). 

## Issue
https://lacework.atlassian.net/browse/GROW-2760
